### PR TITLE
支払予定日にカレンダー入力を追加

### DIFF
--- a/BourbonWeb/Views/Samples/InputConditions.cshtml
+++ b/BourbonWeb/Views/Samples/InputConditions.cshtml
@@ -13,6 +13,7 @@
     <div class="d-flex align-items-center mt-2">
         <label for="siharaiYoteiYmd" class="me-2 fixed-width-sm">支払予定日</label>
         <input type="text" id="siharaiYoteiYmd" name="siharaiYoteiYmd" class="form-control form-control-sm fixed-width-mdc" value="@(ViewData["CurrentSiharaiYoteiYmd"])" />
+        <input type="date" id="siharaiYoteiYmdPicker" style="position:absolute; left:-9999px;" />
     </div>
     <div class="d-flex align-items-center mt-2">
         <label for="keihishoCd" class="me-2 fixed-width-sm">経費所</label>
@@ -60,6 +61,7 @@
         const ymInput = document.getElementById('sinseiTaishoYm');
         const ymPicker = document.getElementById('sinseiTaishoYmPicker');
         const siharaiInput = document.getElementById('siharaiYoteiYmd');
+        const siharaiPicker = document.getElementById('siharaiYoteiYmdPicker');
         const form = ymInput.closest('form');
 
         const toDisplayYm = (value) => {
@@ -80,6 +82,13 @@
         };
 
         const toInputYmd = (value) => value.replace(/[^0-9]/g, '');
+
+        const toPickerYmd = (value) => {
+            const digits = toInputYmd(value);
+            return digits.length === 8
+                ? `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`
+                : '';
+        };
 
         if (ymInput.value) {
             ymInput.value = toDisplayYm(ymInput.value);
@@ -116,6 +125,17 @@
 
         siharaiInput.addEventListener('blur', () => {
             siharaiInput.value = toDisplayYmd(siharaiInput.value);
+        });
+
+        siharaiInput.addEventListener('click', () => {
+            siharaiPicker.value = toPickerYmd(siharaiInput.value);
+            if (siharaiPicker.showPicker) {
+                siharaiPicker.showPicker();
+            }
+        });
+
+        siharaiPicker.addEventListener('change', () => {
+            siharaiInput.value = toDisplayYmd(siharaiPicker.value);
         });
 
         form.addEventListener('submit', () => {


### PR DESCRIPTION
## Summary
- 支払予定日の検索条件に日付ピッカーを追加し、手入力形式(yyyyMMdd)と表示形式(yyyy年MM月dd日)を維持
- 日付ピッカーとテキスト入力を同期するJavaScriptを追加

## Testing
- `dotnet build` *(コマンド未検出)*
- `apt-get install -y dotnet-sdk-7.0` *(パッケージ未検出)*

------
https://chatgpt.com/codex/tasks/task_b_689bdbe780a083208428abf901a035fc