### PR TITLE
支払予定日の検索条件にカレンダー入力を追加

### DIFF
--- a/BourbonWeb/Views/Samples/InputConditions.cshtml
+++ b/BourbonWeb/Views/Samples/InputConditions.cshtml
@@ -13,6 +13,7 @@
     <div class="d-flex align-items-center mt-2">
         <label for="siharaiYoteiYmd" class="me-2 fixed-width-sm">支払予定日</label>
         <input type="text" id="siharaiYoteiYmd" name="siharaiYoteiYmd" class="form-control form-control-sm fixed-width-mdc" value="@(ViewData["CurrentSiharaiYoteiYmd"])" />
+        <input type="date" id="siharaiYoteiYmdPicker" style="position:absolute; left:-9999px;" disabled />
     </div>
     <div class="d-flex align-items-center mt-2">
         <label for="keihishoCd" class="me-2 fixed-width-sm">経費所</label>
@@ -233,6 +234,7 @@
         const ymInput = document.getElementById('sinseiTaishoYm');
         const ymPicker = document.getElementById('sinseiTaishoYmPicker');
         const siharaiInput = document.getElementById('siharaiYoteiYmd');
+        const siharaiPicker = document.getElementById('siharaiYoteiYmdPicker');
         const form = ymInput.closest('form');
 
         const toDisplayYm = (value) => {
@@ -253,6 +255,11 @@
         };
 
         const toInputYmd = (value) => value.replace(/[^0-9]/g, '');
+
+        const toPickerYmd = (value) => {
+            const digits = toInputYmd(value);
+            return digits.length === 8 ? `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}` : '';
+        };
 
         if (ymInput.value) {
             ymInput.value = toDisplayYm(ymInput.value);
@@ -287,8 +294,27 @@
             siharaiInput.select();
         });
 
+        siharaiInput.addEventListener('click', () => {
+            siharaiPicker.disabled = false;
+            siharaiPicker.value = toPickerYmd(siharaiInput.value);
+            if (siharaiPicker.showPicker) {
+                siharaiPicker.showPicker();
+            }
+        });
+
         siharaiInput.addEventListener('blur', () => {
             siharaiInput.value = toDisplayYmd(siharaiInput.value);
+        });
+
+        siharaiPicker.addEventListener('change', () => {
+            siharaiInput.value = toDisplayYmd(siharaiPicker.value);
+            siharaiPicker.disabled = true;
+            siharaiInput.focus();
+        });
+
+        siharaiPicker.addEventListener('blur', () => {
+            siharaiPicker.disabled = true;
+            siharaiInput.focus();
         });
 
         form.addEventListener('submit', () => {


### PR DESCRIPTION
## 概要
- 支払予定日の検索条件にカレンダーからの日付選択を追加
- 日付の入力形式・表示形式を維持したままカレンダー選択に対応

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_b_689c12d78dec8320ac5c3f78328cfd0e