### PR TITLE
Enable calendar input for payment due date

### DIFF
--- a/BourbonWeb/Views/Samples/InputConditions.cshtml
+++ b/BourbonWeb/Views/Samples/InputConditions.cshtml
@@ -13,6 +13,7 @@
     <div class="d-flex align-items-center mt-2">
         <label for="siharaiYoteiYmd" class="me-2 fixed-width-sm">支払予定日</label>
         <input type="text" id="siharaiYoteiYmd" name="siharaiYoteiYmd" class="form-control form-control-sm fixed-width-mdc" value="@(ViewData["CurrentSiharaiYoteiYmd"])" />
+        <input type="date" id="siharaiYoteiYmdPicker" style="position:absolute; left:-9999px;" />
     </div>
     <div class="d-flex align-items-center mt-2">
         <label for="keihishoCd" class="me-2 fixed-width-sm">経費所</label>
@@ -222,7 +223,6 @@
     <div class="card-body">
         <ul class="mb-0">
             <li>対象年月にカレンダー入力を追加</li>
-            <li>支払予定日にカレンダー入力を追加</li>
             <li>Functionキー対応</li>
         </ul>
     </div>
@@ -233,6 +233,7 @@
         const ymInput = document.getElementById('sinseiTaishoYm');
         const ymPicker = document.getElementById('sinseiTaishoYmPicker');
         const siharaiInput = document.getElementById('siharaiYoteiYmd');
+        const siharaiPicker = document.getElementById('siharaiYoteiYmdPicker');
         const form = ymInput.closest('form');
 
         const toDisplayYm = (value) => {
@@ -253,6 +254,11 @@
         };
 
         const toInputYmd = (value) => value.replace(/[^0-9]/g, '');
+
+        const toPickerYmd = (value) => {
+            const digits = toInputYmd(value);
+            return digits.length === 8 ? `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}` : '';
+        };
 
         if (ymInput.value) {
             ymInput.value = toDisplayYm(ymInput.value);
@@ -287,8 +293,19 @@
             siharaiInput.select();
         });
 
+        siharaiInput.addEventListener('click', () => {
+            siharaiPicker.value = toPickerYmd(siharaiInput.value);
+            if (siharaiPicker.showPicker) {
+                siharaiPicker.showPicker();
+            }
+        });
+
         siharaiInput.addEventListener('blur', () => {
             siharaiInput.value = toDisplayYmd(siharaiInput.value);
+        });
+
+        siharaiPicker.addEventListener('change', () => {
+            siharaiInput.value = toDisplayYmd(siharaiPicker.value);
         });
 
         form.addEventListener('submit', () => {


### PR DESCRIPTION
## Summary
- allow calendar selection for 支払予定日 while preserving existing formats

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_b_689c12d78dec8320ac5c3f78328cfd0e