### PR TITLE
支払予定日にカレンダー入力を追加

### DIFF
--- a/BourbonWeb/Views/Samples/InputConditions.cshtml
+++ b/BourbonWeb/Views/Samples/InputConditions.cshtml
@@ -14,9 +14,11 @@
         <label for="siharaiYoteiYmd" class="me-2 fixed-width-sm">支払予定日</label>
         <div class="input-group input-group-sm fixed-width-mdc">
             <input type="text" id="siharaiYoteiYmd" name="siharaiYoteiYmd" class="form-control" value="@(ViewData["CurrentSiharaiYoteiYmd"])" />
-            <span class="input-group-text" id="siharaiYoteiYmdIcon" style="cursor: pointer;"><i class="bi bi-calendar3"></i></span>
+            <span class="input-group-text position-relative p-0">
+                <i class="bi bi-calendar3"></i>
+                <input type="date" id="siharaiYoteiYmdPicker" class="position-absolute top-0 start-0 opacity-0" style="width:100%; height:100%; cursor:pointer;" />
+            </span>
         </div>
-        <input type="date" id="siharaiYoteiYmdPicker" style="position:absolute; left:-9999px;" />
     </div>
     <div class="d-flex align-items-center mt-2">
         <label for="keihishoCd" class="me-2 fixed-width-sm">経費所</label>
@@ -238,7 +240,6 @@
         const ymPicker = document.getElementById('sinseiTaishoYmPicker');
         const siharaiInput = document.getElementById('siharaiYoteiYmd');
         const siharaiPicker = document.getElementById('siharaiYoteiYmdPicker');
-        const siharaiIcon = document.getElementById('siharaiYoteiYmdIcon');
         const form = ymInput.closest('form');
         const searchButton = document.getElementById('searchButton');
 
@@ -301,11 +302,8 @@
             ymInput.value = toDisplayYm(ymPicker.value);
         });
 
-        siharaiIcon.addEventListener('click', () => {
+        siharaiPicker.addEventListener('focus', () => {
             siharaiPicker.value = toPickerYmd(siharaiInput.value);
-            if (siharaiPicker.showPicker) {
-                siharaiPicker.showPicker();
-            }
         });
 
         siharaiPicker.addEventListener('change', () => {

--- a/BourbonWeb/Views/Samples/InputConditions.cshtml
+++ b/BourbonWeb/Views/Samples/InputConditions.cshtml
@@ -12,8 +12,8 @@
     </div>
     <div class="d-flex align-items-center mt-2">
         <label for="siharaiYoteiYmd" class="me-2 fixed-width-sm">支払予定日</label>
-        <div class="input-group input-group-sm fixed-width-mdc">
-            <input type="text" id="siharaiYoteiYmd" name="siharaiYoteiYmd" class="form-control" value="@(ViewData["CurrentSiharaiYoteiYmd"])" />
+        <div class="input-group input-group-sm fixed-width-md">
+            <input type="text" id="siharaiYoteiYmd" name="siharaiYoteiYmd" class="form-control text-center" value="@(ViewData["CurrentSiharaiYoteiYmd"])" />
             <span class="input-group-text position-relative p-0">
                 <i class="bi bi-calendar3"></i>
                 <input type="date" id="siharaiYoteiYmdPicker" class="position-absolute top-0 start-0 opacity-0" style="width:100%; height:100%; cursor:pointer;" />
@@ -127,7 +127,7 @@
         <label for="sinseiNo" class="me-2 fixed-width-sm">申請番号</label>
         <input type="text" id="sinseiNo" name="sinseiNo" class="form-control form-control-sm fixed-width-mdc" />
     </div>
-    <div class="mt-2">
+    <div class="mt-3">
         <button type="submit" id="searchButton" class="btn btn-sm btn-primary px-4">検索 (F10)</button>
     </div>
     <input type="hidden" name="pageNumber" value="1" />

--- a/BourbonWeb/Views/Samples/InputConditions.cshtml
+++ b/BourbonWeb/Views/Samples/InputConditions.cshtml
@@ -12,7 +12,11 @@
     </div>
     <div class="d-flex align-items-center mt-2">
         <label for="siharaiYoteiYmd" class="me-2 fixed-width-sm">支払予定日</label>
-        <input type="text" id="siharaiYoteiYmd" name="siharaiYoteiYmd" class="form-control form-control-sm fixed-width-mdc" value="@(ViewData["CurrentSiharaiYoteiYmd"])" />
+        <div class="input-group input-group-sm fixed-width-mdc">
+            <input type="text" id="siharaiYoteiYmd" name="siharaiYoteiYmd" class="form-control" value="@(ViewData["CurrentSiharaiYoteiYmd"])" />
+            <span class="input-group-text" id="siharaiYoteiYmdIcon" style="cursor: pointer;"><i class="bi bi-calendar3"></i></span>
+        </div>
+        <input type="date" id="siharaiYoteiYmdPicker" style="position:absolute; left:-9999px;" />
     </div>
     <div class="d-flex align-items-center mt-2">
         <label for="keihishoCd" class="me-2 fixed-width-sm">経費所</label>
@@ -233,6 +237,8 @@
         const ymInput = document.getElementById('sinseiTaishoYm');
         const ymPicker = document.getElementById('sinseiTaishoYmPicker');
         const siharaiInput = document.getElementById('siharaiYoteiYmd');
+        const siharaiPicker = document.getElementById('siharaiYoteiYmdPicker');
+        const siharaiIcon = document.getElementById('siharaiYoteiYmdIcon');
         const form = ymInput.closest('form');
         const searchButton = document.getElementById('searchButton');
 
@@ -262,6 +268,11 @@
 
         const toInputYmd = (value) => value.replace(/[^0-9]/g, '');
 
+        const toPickerYmd = (value) => {
+            const digits = toInputYmd(value);
+            return digits.length === 8 ? `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}` : '';
+        };
+
         if (ymInput.value) {
             ymInput.value = toDisplayYm(ymInput.value);
         }
@@ -288,6 +299,17 @@
 
         ymPicker.addEventListener('change', () => {
             ymInput.value = toDisplayYm(ymPicker.value);
+        });
+
+        siharaiIcon.addEventListener('click', () => {
+            siharaiPicker.value = toPickerYmd(siharaiInput.value);
+            if (siharaiPicker.showPicker) {
+                siharaiPicker.showPicker();
+            }
+        });
+
+        siharaiPicker.addEventListener('change', () => {
+            siharaiInput.value = toDisplayYmd(siharaiPicker.value);
         });
 
         siharaiInput.addEventListener('focus', () => {


### PR DESCRIPTION
## 概要
- 支払予定日入力欄にカレンダーアイコンを追加し、カレンダーからの日付選択を可能にしました
- 表示・入力形式（yyyy年MM月dd日/ yyyyMMdd）の変換とEnterキー移動機能を維持しました

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_b_689c1fbaaca08320972402cf9ca4d005