### PR TITLE
Add dynamic sitemap page and sidebar link

### DIFF
--- a/BourbonWeb/Controllers/HomeController.cs
+++ b/BourbonWeb/Controllers/HomeController.cs
@@ -1,16 +1,23 @@
 using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
 using BourbonWeb.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 
 namespace BourbonWeb.Controllers
 {
     public class HomeController : Controller
     {
         private readonly ILogger<HomeController> _logger;
+        private readonly IActionDescriptorCollectionProvider _actions;
 
-        public HomeController(ILogger<HomeController> logger)
+        public HomeController(ILogger<HomeController> logger, IActionDescriptorCollectionProvider actions)
         {
             _logger = logger;
+            _actions = actions;
         }
 
         public IActionResult Index()
@@ -26,6 +33,34 @@ namespace BourbonWeb.Controllers
         public IActionResult UnderConstruction()
         {
             return View();
+        }
+
+        public IActionResult Sitemap()
+        {
+            var descriptors = _actions.ActionDescriptors.Items
+                .OfType<ControllerActionDescriptor>();
+
+            var urls = new List<string>();
+            foreach (var d in descriptors)
+            {
+                var httpMethods = d.ActionConstraints?
+                    .OfType<HttpMethodActionConstraint>()
+                    .FirstOrDefault()?.HttpMethods;
+
+                if (httpMethods != null && !httpMethods.Contains("GET"))
+                {
+                    continue;
+                }
+
+                var area = d.RouteValues.ContainsKey("area") ? d.RouteValues["area"] : null;
+                var url = Url.Action(d.ActionName, d.ControllerName, new { area });
+                if (!string.IsNullOrEmpty(url))
+                {
+                    urls.Add(url);
+                }
+            }
+
+            return View(urls);
         }
 
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]

--- a/BourbonWeb/Views/Home/Sitemap.cshtml
+++ b/BourbonWeb/Views/Home/Sitemap.cshtml
@@ -1,0 +1,11 @@
+@model IEnumerable<string>
+@{
+    ViewData["Title"] = "サイトマップ";
+}
+<h1>サイトマップ</h1>
+<ul>
+@foreach (var url in Model.Distinct().OrderBy(u => u))
+{
+    <li><a href="@url">@url</a></li>
+}
+</ul>

--- a/BourbonWeb/Views/Shared/_Layout.cshtml
+++ b/BourbonWeb/Views/Shared/_Layout.cshtml
@@ -120,6 +120,11 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a asp-area="" asp-controller="Home" asp-action="Sitemap" class="nav-link">
+                            <p>サイトマップ</p>
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a asp-area="" asp-controller="Home" asp-action="Index" class="nav-link">
                             <i class="nav-icon bi bi-house"></i>
                             <p>Home</p>


### PR DESCRIPTION
## Summary
- add sitemap page that scans action descriptors to list GET routes
- link sitemap from the sidebar navigation

## Testing
- `dotnet build` *(fails: Unrecognized escape sequence errors in existing model files)*

------
https://chatgpt.com/codex/tasks/task_b_68a3bde3eb0483209f1af5e1021a5bb0