### PR TITLE
feat: add page size selection for home lists

### DIFF
--- a/BourbonWeb/Controllers/SamplesController.cs
+++ b/BourbonWeb/Controllers/SamplesController.cs
@@ -337,7 +337,7 @@ FROM
             return View(list);
         }
 
-        public async Task<IActionResult> Home(int? mainPageNumber, int? queryPageNumber)
+        public async Task<IActionResult> Home(int? mainPageNumber, int? queryPageNumber, int? mainPageSize, int? queryPageSize)
         {
             var baseQuery = _context.HansokuSinsei
                 .FromSqlRaw(sql)
@@ -354,11 +354,12 @@ FROM
                 .OrderByDescending(s => s.ShuseiKagamiNo)
                 .ThenByDescending(s => s.SinseiNo);
 
-            int pageSize = 5;
+            int mainSize = mainPageSize ?? 5;
+            int querySize = queryPageSize ?? 5;
             var viewModel = new HomeViewModel
             {
-                MainList = await PaginatedList<HansokuSinsei>.CreateAsync(baseQuery, mainPageNumber ?? 1, pageSize),
-                QueryList = await PaginatedList<HansokuSinsei>.CreateAsync(queryResult, queryPageNumber ?? 1, pageSize)
+                MainList = await PaginatedList<HansokuSinsei>.CreateAsync(baseQuery, mainPageNumber ?? 1, mainSize),
+                QueryList = await PaginatedList<HansokuSinsei>.CreateAsync(queryResult, queryPageNumber ?? 1, querySize)
             };
             return View(viewModel);
         }

--- a/BourbonWeb/Views/Samples/Home.cshtml
+++ b/BourbonWeb/Views/Samples/Home.cshtml
@@ -72,8 +72,9 @@
 @await Html.PartialAsync("_KagamiNotCreatedTable", Model.MainList)
 
 <nav aria-label="page navigation" class="mt-3">
-    <div class="d-flex justify-content-center align-items-center">
-        <ul class="pagination justify-content-center mb-0">
+    <div class="d-flex align-items-center w-100">
+        <div class="flex-grow-1 d-flex justify-content-center">
+            <ul class="pagination mb-0">
             <li class="page-item @(Model.MainList.HasPreviousPage ? "" : "disabled")">
                 <a class="page-link" asp-route-mainPageNumber="@(Model.MainList.PageIndex - 1)" asp-route-queryPageNumber="@Model.QueryList.PageIndex" asp-route-mainPageSize="@Model.MainList.PageSize" asp-route-queryPageSize="@Model.QueryList.PageSize">前へ</a>
             </li>
@@ -103,13 +104,14 @@
             <li class="page-item @(Model.MainList.HasNextPage ? "" : "disabled")">
                 <a class="page-link" asp-route-mainPageNumber="@(Model.MainList.PageIndex + 1)" asp-route-queryPageNumber="@Model.QueryList.PageIndex" asp-route-mainPageSize="@Model.MainList.PageSize" asp-route-queryPageSize="@Model.QueryList.PageSize">次へ</a>
             </li>
-        </ul>
+            </ul>
+        </div>
         <form method="get" class="ms-2">
             <select name="mainPageSize" class="form-select form-select-sm" onchange="this.form.submit()">
-                <option value="5" selected="@(Model.MainList.PageSize == 5)">5件</option>
-                <option value="10" selected="@(Model.MainList.PageSize == 10)">10件</option>
-                <option value="25" selected="@(Model.MainList.PageSize == 25)">25件</option>
-                <option value="50" selected="@(Model.MainList.PageSize == 50)">50件</option>
+                <option value="5" @(Model.MainList.PageSize == 5 ? "selected" : null)>5件</option>
+                <option value="10" @(Model.MainList.PageSize == 10 ? "selected" : null)>10件</option>
+                <option value="25" @(Model.MainList.PageSize == 25 ? "selected" : null)>25件</option>
+                <option value="50" @(Model.MainList.PageSize == 50 ? "selected" : null)>50件</option>
             </select>
             <input type="hidden" name="mainPageNumber" value="1" />
             <input type="hidden" name="queryPageNumber" value="@Model.QueryList.PageIndex" />
@@ -142,8 +144,9 @@
 @await Html.PartialAsync("_AwaitingPaymentTable", Model.QueryList)
 
 <nav aria-label="page navigation" class="mt-3">
-    <div class="d-flex justify-content-center align-items-center">
-        <ul class="pagination justify-content-center mb-0">
+    <div class="d-flex align-items-center w-100">
+        <div class="flex-grow-1 d-flex justify-content-center">
+            <ul class="pagination mb-0">
             <li class="page-item @(Model.QueryList.HasPreviousPage ? "" : "disabled")">
                 <a class="page-link" asp-route-queryPageNumber="@(Model.QueryList.PageIndex - 1)" asp-route-mainPageNumber="@Model.MainList.PageIndex" asp-route-mainPageSize="@Model.MainList.PageSize" asp-route-queryPageSize="@Model.QueryList.PageSize">前へ</a>
             </li>
@@ -173,13 +176,14 @@
             <li class="page-item @(Model.QueryList.HasNextPage ? "" : "disabled")">
                 <a class="page-link" asp-route-queryPageNumber="@(Model.QueryList.PageIndex + 1)" asp-route-mainPageNumber="@Model.MainList.PageIndex" asp-route-mainPageSize="@Model.MainList.PageSize" asp-route-queryPageSize="@Model.QueryList.PageSize">次へ</a>
             </li>
-        </ul>
+            </ul>
+        </div>
         <form method="get" class="ms-2">
             <select name="queryPageSize" class="form-select form-select-sm" onchange="this.form.submit()">
-                <option value="5" selected="@(Model.QueryList.PageSize == 5)">5件</option>
-                <option value="10" selected="@(Model.QueryList.PageSize == 10)">10件</option>
-                <option value="25" selected="@(Model.QueryList.PageSize == 25)">25件</option>
-                <option value="50" selected="@(Model.QueryList.PageSize == 50)">50件</option>
+                <option value="5" @(Model.QueryList.PageSize == 5 ? "selected" : null)>5件</option>
+                <option value="10" @(Model.QueryList.PageSize == 10 ? "selected" : null)>10件</option>
+                <option value="25" @(Model.QueryList.PageSize == 25 ? "selected" : null)>25件</option>
+                <option value="50" @(Model.QueryList.PageSize == 50 ? "selected" : null)>50件</option>
             </select>
             <input type="hidden" name="queryPageNumber" value="1" />
             <input type="hidden" name="mainPageNumber" value="@Model.MainList.PageIndex" />

--- a/BourbonWeb/Views/Samples/Home.cshtml
+++ b/BourbonWeb/Views/Samples/Home.cshtml
@@ -106,10 +106,10 @@
         </ul>
         <form method="get" class="ms-2">
             <select name="mainPageSize" class="form-select form-select-sm" onchange="this.form.submit()">
-                <option value="5" @(Model.MainList.PageSize == 5 ? "selected" : "")>5件</option>
-                <option value="10" @(Model.MainList.PageSize == 10 ? "selected" : "")>10件</option>
-                <option value="25" @(Model.MainList.PageSize == 25 ? "selected" : "")>25件</option>
-                <option value="50" @(Model.MainList.PageSize == 50 ? "selected" : "")>50件</option>
+                <option value="5" selected="@(Model.MainList.PageSize == 5)">5件</option>
+                <option value="10" selected="@(Model.MainList.PageSize == 10)">10件</option>
+                <option value="25" selected="@(Model.MainList.PageSize == 25)">25件</option>
+                <option value="50" selected="@(Model.MainList.PageSize == 50)">50件</option>
             </select>
             <input type="hidden" name="mainPageNumber" value="1" />
             <input type="hidden" name="queryPageNumber" value="@Model.QueryList.PageIndex" />
@@ -176,10 +176,10 @@
         </ul>
         <form method="get" class="ms-2">
             <select name="queryPageSize" class="form-select form-select-sm" onchange="this.form.submit()">
-                <option value="5" @(Model.QueryList.PageSize == 5 ? "selected" : "")>5件</option>
-                <option value="10" @(Model.QueryList.PageSize == 10 ? "selected" : "")>10件</option>
-                <option value="25" @(Model.QueryList.PageSize == 25 ? "selected" : "")>25件</option>
-                <option value="50" @(Model.QueryList.PageSize == 50 ? "selected" : "")>50件</option>
+                <option value="5" selected="@(Model.QueryList.PageSize == 5)">5件</option>
+                <option value="10" selected="@(Model.QueryList.PageSize == 10)">10件</option>
+                <option value="25" selected="@(Model.QueryList.PageSize == 25)">25件</option>
+                <option value="50" selected="@(Model.QueryList.PageSize == 50)">50件</option>
             </select>
             <input type="hidden" name="queryPageNumber" value="1" />
             <input type="hidden" name="mainPageNumber" value="@Model.MainList.PageIndex" />

--- a/BourbonWeb/Views/Samples/Home.cshtml
+++ b/BourbonWeb/Views/Samples/Home.cshtml
@@ -72,37 +72,50 @@
 @await Html.PartialAsync("_KagamiNotCreatedTable", Model.MainList)
 
 <nav aria-label="page navigation" class="mt-3">
-    <ul class="pagination justify-content-center">
-        <li class="page-item @(Model.MainList.HasPreviousPage ? "" : "disabled")">
-            <a class="page-link" asp-route-mainPageNumber="@(Model.MainList.PageIndex - 1)" asp-route-queryPageNumber="@Model.QueryList.PageIndex">前へ</a>
-        </li>
-        <li class="page-item @(Model.MainList.PageIndex == 1 ? "active" : "")">
-            <a class="page-link" asp-route-mainPageNumber="1" asp-route-queryPageNumber="@Model.QueryList.PageIndex">1</a>
-        </li>
-        @if (Model.MainList.PageIndex > 3)
-        {
-            <li class="page-item disabled"><span class="page-link">…</span></li>
-        }
-        @for (var i = Math.Max(2, Model.MainList.PageIndex - 1); i <= Math.Min(Model.MainList.TotalPages - 1, Model.MainList.PageIndex + 1); i++)
-        {
-            <li class="page-item @(i == Model.MainList.PageIndex ? "active" : "")">
-                <a class="page-link" asp-route-mainPageNumber="@i" asp-route-queryPageNumber="@Model.QueryList.PageIndex">@i</a>
+    <div class="d-flex justify-content-center align-items-center">
+        <ul class="pagination justify-content-center mb-0">
+            <li class="page-item @(Model.MainList.HasPreviousPage ? "" : "disabled")">
+                <a class="page-link" asp-route-mainPageNumber="@(Model.MainList.PageIndex - 1)" asp-route-queryPageNumber="@Model.QueryList.PageIndex" asp-route-mainPageSize="@Model.MainList.PageSize" asp-route-queryPageSize="@Model.QueryList.PageSize">前へ</a>
             </li>
-        }
-        @if (Model.MainList.PageIndex < Model.MainList.TotalPages - 2)
-        {
-            <li class="page-item disabled"><span class="page-link">…</span></li>
-        }
-        @if (Model.MainList.TotalPages > 1)
-        {
-            <li class="page-item @(Model.MainList.PageIndex == Model.MainList.TotalPages ? "active" : "")">
-                <a class="page-link" asp-route-mainPageNumber="@Model.MainList.TotalPages" asp-route-queryPageNumber="@Model.QueryList.PageIndex">@Model.MainList.TotalPages</a>
+            <li class="page-item @(Model.MainList.PageIndex == 1 ? "active" : "")">
+                <a class="page-link" asp-route-mainPageNumber="1" asp-route-queryPageNumber="@Model.QueryList.PageIndex" asp-route-mainPageSize="@Model.MainList.PageSize" asp-route-queryPageSize="@Model.QueryList.PageSize">1</a>
             </li>
-        }
-        <li class="page-item @(Model.MainList.HasNextPage ? "" : "disabled")">
-            <a class="page-link" asp-route-mainPageNumber="@(Model.MainList.PageIndex + 1)" asp-route-queryPageNumber="@Model.QueryList.PageIndex">次へ</a>
-        </li>
-    </ul>
+            @if (Model.MainList.PageIndex > 3)
+            {
+                <li class="page-item disabled"><span class="page-link">…</span></li>
+            }
+            @for (var i = Math.Max(2, Model.MainList.PageIndex - 1); i <= Math.Min(Model.MainList.TotalPages - 1, Model.MainList.PageIndex + 1); i++)
+            {
+                <li class="page-item @(i == Model.MainList.PageIndex ? "active" : "")">
+                    <a class="page-link" asp-route-mainPageNumber="@i" asp-route-queryPageNumber="@Model.QueryList.PageIndex" asp-route-mainPageSize="@Model.MainList.PageSize" asp-route-queryPageSize="@Model.QueryList.PageSize">@i</a>
+                </li>
+            }
+            @if (Model.MainList.PageIndex < Model.MainList.TotalPages - 2)
+            {
+                <li class="page-item disabled"><span class="page-link">…</span></li>
+            }
+            @if (Model.MainList.TotalPages > 1)
+            {
+                <li class="page-item @(Model.MainList.PageIndex == Model.MainList.TotalPages ? "active" : "")">
+                    <a class="page-link" asp-route-mainPageNumber="@Model.MainList.TotalPages" asp-route-queryPageNumber="@Model.QueryList.PageIndex" asp-route-mainPageSize="@Model.MainList.PageSize" asp-route-queryPageSize="@Model.QueryList.PageSize">@Model.MainList.TotalPages</a>
+                </li>
+            }
+            <li class="page-item @(Model.MainList.HasNextPage ? "" : "disabled")">
+                <a class="page-link" asp-route-mainPageNumber="@(Model.MainList.PageIndex + 1)" asp-route-queryPageNumber="@Model.QueryList.PageIndex" asp-route-mainPageSize="@Model.MainList.PageSize" asp-route-queryPageSize="@Model.QueryList.PageSize">次へ</a>
+            </li>
+        </ul>
+        <form method="get" class="ms-2">
+            <select name="mainPageSize" class="form-select form-select-sm" onchange="this.form.submit()">
+                <option value="5" @(Model.MainList.PageSize == 5 ? "selected" : "")>5件</option>
+                <option value="10" @(Model.MainList.PageSize == 10 ? "selected" : "")>10件</option>
+                <option value="25" @(Model.MainList.PageSize == 25 ? "selected" : "")>25件</option>
+                <option value="50" @(Model.MainList.PageSize == 50 ? "selected" : "")>50件</option>
+            </select>
+            <input type="hidden" name="mainPageNumber" value="1" />
+            <input type="hidden" name="queryPageNumber" value="@Model.QueryList.PageIndex" />
+            <input type="hidden" name="queryPageSize" value="@Model.QueryList.PageSize" />
+        </form>
+    </div>
 </nav>
 
 <hr />
@@ -129,37 +142,50 @@
 @await Html.PartialAsync("_AwaitingPaymentTable", Model.QueryList)
 
 <nav aria-label="page navigation" class="mt-3">
-    <ul class="pagination justify-content-center">
-        <li class="page-item @(Model.QueryList.HasPreviousPage ? "" : "disabled")">
-            <a class="page-link" asp-route-queryPageNumber="@(Model.QueryList.PageIndex - 1)" asp-route-mainPageNumber="@Model.MainList.PageIndex">前へ</a>
-        </li>
-        <li class="page-item @(Model.QueryList.PageIndex == 1 ? "active" : "")">
-            <a class="page-link" asp-route-queryPageNumber="1" asp-route-mainPageNumber="@Model.MainList.PageIndex">1</a>
-        </li>
-        @if (Model.QueryList.PageIndex > 3)
-        {
-            <li class="page-item disabled"><span class="page-link">…</span></li>
-        }
-        @for (var i = Math.Max(2, Model.QueryList.PageIndex - 1); i <= Math.Min(Model.QueryList.TotalPages - 1, Model.QueryList.PageIndex + 1); i++)
-        {
-            <li class="page-item @(i == Model.QueryList.PageIndex ? "active" : "")">
-                <a class="page-link" asp-route-queryPageNumber="@i" asp-route-mainPageNumber="@Model.MainList.PageIndex">@i</a>
+    <div class="d-flex justify-content-center align-items-center">
+        <ul class="pagination justify-content-center mb-0">
+            <li class="page-item @(Model.QueryList.HasPreviousPage ? "" : "disabled")">
+                <a class="page-link" asp-route-queryPageNumber="@(Model.QueryList.PageIndex - 1)" asp-route-mainPageNumber="@Model.MainList.PageIndex" asp-route-mainPageSize="@Model.MainList.PageSize" asp-route-queryPageSize="@Model.QueryList.PageSize">前へ</a>
             </li>
-        }
-        @if (Model.QueryList.PageIndex < Model.QueryList.TotalPages - 2)
-        {
-            <li class="page-item disabled"><span class="page-link">…</span></li>
-        }
-        @if (Model.QueryList.TotalPages > 1)
-        {
-            <li class="page-item @(Model.QueryList.PageIndex == Model.QueryList.TotalPages ? "active" : "")">
-                <a class="page-link" asp-route-queryPageNumber="@Model.QueryList.TotalPages" asp-route-mainPageNumber="@Model.MainList.PageIndex">@Model.QueryList.TotalPages</a>
+            <li class="page-item @(Model.QueryList.PageIndex == 1 ? "active" : "")">
+                <a class="page-link" asp-route-queryPageNumber="1" asp-route-mainPageNumber="@Model.MainList.PageIndex" asp-route-mainPageSize="@Model.MainList.PageSize" asp-route-queryPageSize="@Model.QueryList.PageSize">1</a>
             </li>
-        }
-        <li class="page-item @(Model.QueryList.HasNextPage ? "" : "disabled")">
-            <a class="page-link" asp-route-queryPageNumber="@(Model.QueryList.PageIndex + 1)" asp-route-mainPageNumber="@Model.MainList.PageIndex">次へ</a>
-        </li>
-    </ul>
+            @if (Model.QueryList.PageIndex > 3)
+            {
+                <li class="page-item disabled"><span class="page-link">…</span></li>
+            }
+            @for (var i = Math.Max(2, Model.QueryList.PageIndex - 1); i <= Math.Min(Model.QueryList.TotalPages - 1, Model.QueryList.PageIndex + 1); i++)
+            {
+                <li class="page-item @(i == Model.QueryList.PageIndex ? "active" : "")">
+                    <a class="page-link" asp-route-queryPageNumber="@i" asp-route-mainPageNumber="@Model.MainList.PageIndex" asp-route-mainPageSize="@Model.MainList.PageSize" asp-route-queryPageSize="@Model.QueryList.PageSize">@i</a>
+                </li>
+            }
+            @if (Model.QueryList.PageIndex < Model.QueryList.TotalPages - 2)
+            {
+                <li class="page-item disabled"><span class="page-link">…</span></li>
+            }
+            @if (Model.QueryList.TotalPages > 1)
+            {
+                <li class="page-item @(Model.QueryList.PageIndex == Model.QueryList.TotalPages ? "active" : "")">
+                    <a class="page-link" asp-route-queryPageNumber="@Model.QueryList.TotalPages" asp-route-mainPageNumber="@Model.MainList.PageIndex" asp-route-mainPageSize="@Model.MainList.PageSize" asp-route-queryPageSize="@Model.QueryList.PageSize">@Model.QueryList.TotalPages</a>
+                </li>
+            }
+            <li class="page-item @(Model.QueryList.HasNextPage ? "" : "disabled")">
+                <a class="page-link" asp-route-queryPageNumber="@(Model.QueryList.PageIndex + 1)" asp-route-mainPageNumber="@Model.MainList.PageIndex" asp-route-mainPageSize="@Model.MainList.PageSize" asp-route-queryPageSize="@Model.QueryList.PageSize">次へ</a>
+            </li>
+        </ul>
+        <form method="get" class="ms-2">
+            <select name="queryPageSize" class="form-select form-select-sm" onchange="this.form.submit()">
+                <option value="5" @(Model.QueryList.PageSize == 5 ? "selected" : "")>5件</option>
+                <option value="10" @(Model.QueryList.PageSize == 10 ? "selected" : "")>10件</option>
+                <option value="25" @(Model.QueryList.PageSize == 25 ? "selected" : "")>25件</option>
+                <option value="50" @(Model.QueryList.PageSize == 50 ? "selected" : "")>50件</option>
+            </select>
+            <input type="hidden" name="queryPageNumber" value="1" />
+            <input type="hidden" name="mainPageNumber" value="@Model.MainList.PageIndex" />
+            <input type="hidden" name="mainPageSize" value="@Model.MainList.PageSize" />
+        </form>
+    </div>
 </nav>
 
 <hr />

--- a/BourbonWeb/Views/Samples/Home.cshtml
+++ b/BourbonWeb/Views/Samples/Home.cshtml
@@ -108,10 +108,10 @@
         </div>
         <form method="get" class="ms-2">
             <select name="mainPageSize" class="form-select form-select-sm" onchange="this.form.submit()">
-                <option value="5" @(Model.MainList.PageSize == 5 ? "selected" : null)>5件</option>
-                <option value="10" @(Model.MainList.PageSize == 10 ? "selected" : null)>10件</option>
-                <option value="25" @(Model.MainList.PageSize == 25 ? "selected" : null)>25件</option>
-                <option value="50" @(Model.MainList.PageSize == 50 ? "selected" : null)>50件</option>
+                <option value="5" selected="@(Model.MainList.PageSize == 5)">5件</option>
+                <option value="10" selected="@(Model.MainList.PageSize == 10)">10件</option>
+                <option value="25" selected="@(Model.MainList.PageSize == 25)">25件</option>
+                <option value="50" selected="@(Model.MainList.PageSize == 50)">50件</option>
             </select>
             <input type="hidden" name="mainPageNumber" value="1" />
             <input type="hidden" name="queryPageNumber" value="@Model.QueryList.PageIndex" />
@@ -180,10 +180,10 @@
         </div>
         <form method="get" class="ms-2">
             <select name="queryPageSize" class="form-select form-select-sm" onchange="this.form.submit()">
-                <option value="5" @(Model.QueryList.PageSize == 5 ? "selected" : null)>5件</option>
-                <option value="10" @(Model.QueryList.PageSize == 10 ? "selected" : null)>10件</option>
-                <option value="25" @(Model.QueryList.PageSize == 25 ? "selected" : null)>25件</option>
-                <option value="50" @(Model.QueryList.PageSize == 50 ? "selected" : null)>50件</option>
+                <option value="5" selected="@(Model.QueryList.PageSize == 5)">5件</option>
+                <option value="10" selected="@(Model.QueryList.PageSize == 10)">10件</option>
+                <option value="25" selected="@(Model.QueryList.PageSize == 25)">25件</option>
+                <option value="50" selected="@(Model.QueryList.PageSize == 50)">50件</option>
             </select>
             <input type="hidden" name="queryPageNumber" value="1" />
             <input type="hidden" name="mainPageNumber" value="@Model.MainList.PageIndex" />


### PR DESCRIPTION
## Summary
- allow independent page sizes for not-created and awaiting-payment lists
- add page size dropdowns next to paginations

## Testing
- `dotnet build` *(fails: CS1009 unrecognized escape sequence)*

------
https://chatgpt.com/codex/tasks/task_b_68a5486a17c08320bf32b16d121a4c1c