### PR TITLE
Sample一覧画面にCSV出力と登録ボタンを追加

### DIFF
--- a/BourbonWeb/Controllers/SamplesController.cs
+++ b/BourbonWeb/Controllers/SamplesController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -178,6 +179,48 @@ FROM
             query = query.OrderBy(s => s.Id);
             ViewData["CurrentFilter"] = searchString;
             return View(await PaginatedList<Sample>.CreateAsync(query, pageNumber ?? 1, currentPageSize));
+        }
+
+        // GET: Samples/ExportCsv
+        public async Task<IActionResult> ExportCsv()
+        {
+            var samples = await _context.Sample
+                .AsNoTracking()
+                .OrderBy(s => s.Id)
+                .ToListAsync();
+
+            var sb = new StringBuilder();
+            sb.AppendLine("Id,Name,Price,Description,Quantity,Weight,TargetYM,PaymentDate,UpdatedAt,IsActive,Text1,Text2,Text3,Text4,Text5");
+
+            foreach (var s in samples)
+            {
+                var fields = new[]
+                {
+                    Quote(s.Id),
+                    Quote(s.Name),
+                    Quote(s.Price),
+                    Quote(s.Description),
+                    Quote(s.Quantity),
+                    Quote(s.Weight),
+                    Quote(s.TargetYM?.ToString("yyyyMM")),
+                    Quote(s.PaymentDate?.ToString("yyyyMMdd")),
+                    Quote(s.UpdatedAt?.ToString("yyyy-MM-dd HH:mm:ss")),
+                    Quote(s.IsActive),
+                    Quote(s.Text1),
+                    Quote(s.Text2),
+                    Quote(s.Text3),
+                    Quote(s.Text4),
+                    Quote(s.Text5)
+                };
+                sb.AppendLine(string.Join(",", fields));
+            }
+
+            return File(Encoding.UTF8.GetBytes(sb.ToString()), "text/csv", "samples.csv");
+        }
+
+        private static string Quote(object? value)
+        {
+            return $"\"{value?.ToString()?.Replace("\"", "\"\"")}\"";
         }
 
         // GET: Samples

--- a/BourbonWeb/Views/Samples/Index.cshtml
+++ b/BourbonWeb/Views/Samples/Index.cshtml
@@ -5,7 +5,8 @@
 }
 
 <div class="d-flex justify-content-end align-items-center mb-3">
-    <a asp-action="Create" class="btn btn-primary"><i class="bi bi-plus"></i> 新規登録</a>
+    <a asp-action="ExportCsv" class="btn btn-success me-2"><i class="bi bi-download"></i> CSV出力</a>
+    <a asp-action="Create" class="btn btn-primary"><i class="bi bi-plus"></i> 登録</a>
 </div>
 <div class="card">
     <div class="card-header">


### PR DESCRIPTION
## Summary
- Sample一覧画面にCSV出力ボタンと登録ボタンを追加
- SampleデータをCSV形式でダウンロードするExportCsvアクションを実装

## Testing
- `dotnet build BourbonWeb.sln` *(失敗: 他のモデルファイルでCS1009等のエラー)*

------
https://chatgpt.com/codex/tasks/task_b_68acfcdd60988320b602283f9c97797e