### PR TITLE
InputConditions画面にCSV出力機能を追加

### DIFF
--- a/BourbonWeb/Controllers/SamplesController.cs
+++ b/BourbonWeb/Controllers/SamplesController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -466,6 +467,126 @@ FROM
             ViewData["CurrentCreateKeihiRitu"] = condition.CreateKeihiRitu;
             var list = await PaginatedList<HansokuSinsei>.CreateAsync(baseQuery, pageNumber ?? 1, currentPageSize);
             return View(list);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> InputConditionsCsv(HansokuSinseiSearchCondition condition)
+        {
+            if (string.IsNullOrEmpty(condition.SinseiTaishoYm))
+            {
+                condition.SinseiTaishoYm = "2024-08";
+            }
+
+            if (string.IsNullOrEmpty(condition.SiharaiYoteiYmd))
+            {
+                condition.SiharaiYoteiYmd = "2024-09-30";
+            }
+
+            if (string.IsNullOrEmpty(condition.KeihishoCd))
+            {
+                condition.KeihishoCd = "210300";
+            }
+
+            if (string.IsNullOrEmpty(condition.KeihishaCd))
+            {
+                condition.KeihishaCd = "063441";
+            }
+
+            if (string.IsNullOrEmpty(condition.SinseiChoaiCd))
+            {
+                condition.SinseiChoaiCd = "201632";
+            }
+
+            if (string.IsNullOrEmpty(condition.SeikyuKbn))
+            {
+                condition.SeikyuKbn = "0";
+            }
+
+            if (string.IsNullOrEmpty(condition.TorihikiCdA))
+            {
+                condition.TorihikiCdA = "XA0734";
+            }
+
+            if (string.IsNullOrEmpty(condition.ShoriHoho))
+            {
+                condition.ShoriHoho = "20;";
+            }
+
+            if (string.IsNullOrEmpty(condition.KyosanJokenTaniKbn))
+            {
+                condition.KyosanJokenTaniKbn = "0";
+            }
+
+            if (string.IsNullOrEmpty(condition.KakakuHansokuKbn))
+            {
+                condition.KakakuHansokuKbn = "1";
+            }
+
+            if (string.IsNullOrEmpty(condition.CreateKeihiRitu))
+            {
+                condition.CreateKeihiRitu = "0";
+            }
+
+            var baseQuery = _context.HansokuSinsei
+                .FromSqlRaw(sql)
+                .AsNoTracking();
+
+            if (!string.IsNullOrEmpty(condition.SinseiTaishoYm))
+            {
+                var ym = condition.SinseiTaishoYm.Replace("-", "").Replace("年", "").Replace("月", "");
+                baseQuery = baseQuery.Where(s => s.SinseiTaishoYm == ym);
+            }
+
+            if (!string.IsNullOrEmpty(condition.KeihishoCd))
+            {
+                baseQuery = baseQuery.Where(s => s.KeihishoCd == condition.KeihishoCd);
+            }
+
+            if (!string.IsNullOrEmpty(condition.SinseiChoaiCd))
+            {
+                baseQuery = baseQuery.Where(s => s.SinseiChoaiCd == condition.SinseiChoaiCd);
+            }
+
+            if (!string.IsNullOrEmpty(condition.SeikyuKbn))
+            {
+                baseQuery = baseQuery.Where(s => s.SeikyuKbn == condition.SeikyuKbn);
+            }
+
+            baseQuery = baseQuery
+                .OrderByDescending(s => s.SinseiNo);
+
+            var list = await baseQuery.ToListAsync();
+
+            var sb = new StringBuilder();
+            sb.AppendLine("申請番号,対象年月,処理方法,請求区分,帳合CD,帳合店,得意先CD,得意先名,協賛額,費用計上,数量単位区分,経費所CD,経費所名,申請計上年月,訂正申請番号,未確定件数,価格販促区分,経費配分条件");
+
+            foreach (var item in list)
+            {
+                string[] fields = new string[]
+                {
+                    item.SinseiNo,
+                    item.SinseiTaishoYm ?? string.Empty,
+                    item.ShoriHoho ?? string.Empty,
+                    item.SeikyuKbnNm,
+                    item.SinseiChoaiCd ?? string.Empty,
+                    item.SinseiChoaiNm ?? string.Empty,
+                    item.TorihikiCdA ?? string.Empty,
+                    item.TorihikiNmA ?? string.Empty,
+                    item.KyosanGaku?.ToString() ?? string.Empty,
+                    item.HiyoKeijo ?? string.Empty,
+                    item.SuryoTaniKbnNm ?? string.Empty,
+                    item.KeihishoCd ?? string.Empty,
+                    item.KeihishoNm ?? string.Empty,
+                    item.SinseiKeijoYm ?? string.Empty,
+                    item.TeiseiSinseiNo ?? string.Empty,
+                    item.MikakuteiCnt.ToString(),
+                    item.KakakuHansokuKbnNm ?? string.Empty,
+                    item.KeihiHaibunJokenNm ?? string.Empty
+                };
+                sb.AppendLine(string.Join(',', fields.Select(f => $"\"{f.Replace("\"", "\"\"")}\"")));
+            }
+
+            return File(Encoding.UTF8.GetBytes(sb.ToString()), "text/csv", "inputconditions.csv");
         }
 
         public IActionResult CRV0020Sample()

--- a/BourbonWeb/Views/Samples/InputConditions.cshtml
+++ b/BourbonWeb/Views/Samples/InputConditions.cshtml
@@ -18,6 +18,7 @@
 <div class="d-flex align-items-center justify-content-between mb-1 me-1">
     <div class="d-flex align-items-center">
         <a asp-action="CRV0020Sample" id="createButton" class="btn btn-sm btn-secondary btn-fixed">新規登録 (F12)</a>
+        <button type="submit" form="searchForm" formaction="@Url.Action("InputConditionsCsv")" class="btn btn-sm btn-secondary btn-fixed ms-2">CSV出力</button>
     </div>
     <div>
         @Model.TotalCount.ToString("N0") 件


### PR DESCRIPTION
## 概要
- 一覧データをCSVファイルとしてダウンロードできるようにしました
- InputConditions画面にCSV出力ボタンを追加しました

## テスト
- `dotnet build` (コマンド未存在のため失敗)


------
https://chatgpt.com/codex/tasks/task_b_68ad17791c788320a5f6ac7c165e4ccc