### PR TITLE
Add Excel import for samples

### DIFF
--- a/BourbonWeb/Views/Samples/Index.cshtml
+++ b/BourbonWeb/Views/Samples/Index.cshtml
@@ -13,6 +13,12 @@
             <button type="submit" class="btn btn-secondary"><i class="bi bi-upload"></i> CSV取込</button>
         </div>
     </form>
+    <form asp-action="ImportExcel" method="post" enctype="multipart/form-data" class="ms-2">
+        <div class="input-group input-group-sm">
+            <input type="file" name="file" class="form-control" />
+            <button type="submit" class="btn btn-secondary"><i class="bi bi-upload"></i> EXCEL取込</button>
+        </div>
+    </form>
 </div>
 <div class="card">
     <div class="card-header">


### PR DESCRIPTION
## Summary
- add ImportExcel action to handle XLSX uploads for Sample data
- allow uploading Excel files from sample list page

## Testing
- `dotnet build` *(fails: THansokuSinsei.cs unrecognized escape sequence)*

------
https://chatgpt.com/codex/tasks/task_b_68ad371a363083209906fd90d06ab7a1